### PR TITLE
SimplePlastic

### DIFF
--- a/src/MechanicalMaterialModels.jl
+++ b/src/MechanicalMaterialModels.jl
@@ -31,6 +31,9 @@ include("ExtraOutputs.jl")
 include("PlasticDifferentiate.jl")
 export Plastic
 
+include("specialized_models/SimplePlastic.jl")
+export SimplePlastic
+
 include("hyper_elasticity/HyperElastic.jl")
 include("hyper_elasticity/NeoHooke.jl")
 export NeoHooke, CompressibleNeoHooke

--- a/src/specialized_models/SimplePlastic.jl
+++ b/src/specialized_models/SimplePlastic.jl
@@ -1,0 +1,148 @@
+@kwdef struct SimplePlastic{T} <: AbstractMaterial
+    G::T
+    K::T 
+    Y0::T 
+    Hiso::T 
+    κ∞::T 
+    Hkin::T 
+    β∞::T 
+end
+
+function SimplePlastic(mp::Plastic)
+    if !isa(mp.elastic, LinearElastic{<:Any, :isotropic})
+        error("elastic part must be isotropic")
+    end
+    isa(mp.yield, VonMises) || error("yield criterion must be von Mises")
+    if length(mp.isotropic) != 1
+        if !isa(only(mp.isotropic), Voce)
+            error("Only a single isotropic hardening, which must be Voce, is allowed")
+        end
+    end
+    if length(mp.kinematic) != 1
+        if isa(only(mp.kinematic), ArmstrongFrederick)
+            error("Only a single kinematic hardening, which must be ArmstrongFrederick, is allowed")
+        end
+    end
+    isa(mp.overstress, RateIndependent) || error("Only rate-independent material allowed")
+    
+    E, ν = mp.elastic.p 
+    return SimplePlastic(;
+        G  = E/(2 * (1 + ν)), K = E / (3 * (1 - 2 * ν)), Y0 = mp.yield.Y0, 
+        Hiso = only(mp.isotropic).Hiso, κ∞ = only(mp.isotropic).κ∞,
+        Hkin = only(mp.kinematic).Hkin, β∞ = only(mp.kinematic).β∞)
+end
+
+struct SimplePlasticState{T} <: AbstractMaterialState
+    ϵp::SymmetricTensor{2,3,T,6}
+    β::SymmetricTensor{2,3,T,6}
+    κ::T
+end
+
+function MMB.initial_material_state(::SimplePlastic)
+    return SimplePlasticState(zero(SymmetricTensor{2,3}), zero(SymmetricTensor{2,3}), 0.0)
+end
+
+function MMB.material_response(m::SimplePlastic, ϵ::SymmetricTensor{2,3}, old::SimplePlasticState, Δt, args...)
+    σ_trial = 2 * m.G * dev(ϵ - old.ϵp) + 3 * m.K * vol(ϵ)
+    ϕ_trial = vonmises(σ_trial - old.β) - (m.Y0 + old.κ)
+    if ϕ_trial ≤ 0
+        I2 = one(ϵ)
+        IxI = I2 ⊗ I2
+        I4 = one(SymmetricTensor{4,3})
+        E4 = 2 * m.G * (I4 - IxI/3) + m.K * IxI
+        return σ_trial, E4, old 
+    else
+        rf(x) = residual(x, m, ϵ, old)
+        Δλ1, ∂r∂x1, converged = newtonsolve(rf, 0.0)
+        # Workaround to avoid Δλ and ∂r∂x as `Core.Box`:ed
+        Δλ, ∂r∂x = if !converged || Δλ1 < 0 
+            Δλ2 = bisect_solve(rf, ϕ_trial / m.G)
+            ∂r∂x2 = ForwardDiff.derivative(rf, Δλ2)
+            (Δλ2, ∂r∂x2)
+        else
+            (Δλ1, ∂r∂x1)
+        end
+        if true # converged
+            ∂σ∂ϵ = gradient(e -> calculate_sigma(Δλ, m, e, old), ϵ)
+            ∂σ∂x, σ = gradient(x -> calculate_sigma(x, m, ϵ, old), Δλ, :all)
+            ∂r∂ϵ = gradient(e -> residual(Δλ, m, e, old), ϵ)
+            # drdϵ = 0 = ∂r∂ϵ + ∂r∂x * dxdϵ => dxdϵ = - inv(∂r∂x) * ∂r∂ϵ
+            dσdϵ = ∂σ∂ϵ - (∂σ∂x / ∂r∂x) ⊗ ∂r∂ϵ
+
+            σdev, β, κ = calculate_evolution(Δλ, m, ϵ, old)
+            ϵp = old.ϵp + Δλ * (3/2) * (σdev - β) / (m.Y0 + κ)
+
+            return σ, dσdϵ, SimplePlasticState(ϵp, β, κ)
+
+        else
+            throw(MMB.NoLocalConvergence("$(typeof(m)): newtonsolve! didn't converge, ϵ = ", ϵ))
+        end
+    end
+end
+
+function calculate_κ(Δλ, m::SimplePlastic, old::SimplePlasticState)
+    return m.κ∞ * (old.κ + Δλ * m.Hiso) / (m.κ∞ + Δλ * m.Hiso)
+end
+
+function dβ_fun(Δλ, m::SimplePlastic, κ)
+    return m.Y0 + κ + Δλ * m.Hkin * (m.β∞ + m.Y0 + κ) / m.β∞
+end
+
+function calculate_sigma(Δλ, m::SimplePlastic, ϵ::SymmetricTensor, old::SimplePlasticState)
+    σdev, _, _ = calculate_evolution(Δλ, m, ϵ, old)
+    return σdev + 3 * m.K * vol(ϵ)
+end
+
+function calculate_evolution(Δλ, m::SimplePlastic, ϵ::SymmetricTensor, old::SimplePlasticState)
+    κ = calculate_κ(Δλ, m, old)
+    dβ = dβ_fun(Δλ, m, κ)
+    Y = m.Y0 + κ
+    σdev = (2 * m.G * dev(ϵ) - 2 * m.G * (old.ϵp - (3 * Δλ / (2 * Y)) * (old.β * Y / dβ))) / (
+        1 + (3 * m.G * Δλ / Y) * (1 - Δλ * m.Hkin / dβ) )
+    β = (old.β * Y + Δλ * m.Hkin * σdev) / dβ
+    return σdev, β, κ
+end
+
+function residual(Δλ, m::SimplePlastic, ϵ::SymmetricTensor, old::SimplePlasticState)
+    σdev, β, κ = calculate_evolution(Δλ, m, ϵ, old)
+    Φ = vonmises(σdev - β) - (m.Y0 + κ)
+    return Φ
+end
+
+
+function bisect_solve(rf, x0::Number; maxiter = 200, tol = 1e-6)
+    x_left = zero(x0)
+    x_right = x0
+    r_left = rf(x_left)
+    @show r_left
+    @assert r_left < 0 # No need for premature generalization...
+
+    # Move right untill r_right is above zero 
+    r_right = rf(x0)
+    iter = 0
+    while r_right < 0
+        x_left = x_right
+        x_right = 2*x_right 
+        r_right = rf(x_right)
+        println(iter, ": ", (r_right, x_right), " (move right)")
+        iter += 1
+        iter > maxiter && error("Didn't converge (could not find positive value)")
+    end
+
+    # Bisection
+    for i in iter:maxiter
+        # 0 = r_center ≈ r_left + (r_right - r_left) * (x_center - x_left) / (x_right - x_left)
+        x_center = x_left - r_left * (x_right - x_left) / (r_right - r_left)
+        r_center = rf(x_center)
+        println(iter, ": ", (r_center, x_center), " (bisect)")
+        abs(r_center) < tol && return x_center 
+        if r_center < 0
+            x_left = x_center
+            r_left = r_center
+        else
+            x_right = x_center 
+            r_right = r_center 
+        end
+    end
+    error("Did not find sufficiently small residual")
+end

--- a/src/specialized_models/SimplePlastic.jl
+++ b/src/specialized_models/SimplePlastic.jl
@@ -44,6 +44,9 @@ function MMB.material_response(m::SimplePlastic, ϵ::SymmetricTensor{2,3}, old::
         return σ_trial, E4, old 
     else
         rf(x) = residual(x, m, ϵ, old)
+        Δλ, ∂r∂x, converged = newtonsolve(rf, 0.0)
+        #=
+        # Using bisection
         Δλ1, ∂r∂x1, converged = newtonsolve(rf, 0.0)
         # Workaround to avoid Δλ and ∂r∂x as `Core.Box`:ed
         Δλ, ∂r∂x = if !converged || Δλ1 < 0 
@@ -53,7 +56,10 @@ function MMB.material_response(m::SimplePlastic, ϵ::SymmetricTensor{2,3}, old::
         else
             (Δλ1, ∂r∂x1)
         end
-        if true # converged
+        converged = true
+        =#
+
+        if converged
             ∂σ∂ϵ = gradient(e -> calculate_sigma(Δλ, m, e, old), ϵ)
             ∂σ∂x, σ = gradient(x -> calculate_sigma(x, m, ϵ, old), Δλ, :all)
             ∂r∂ϵ = gradient(e -> residual(Δλ, m, e, old), ϵ)

--- a/src/specialized_models/SimplePlastic.jl
+++ b/src/specialized_models/SimplePlastic.jl
@@ -8,22 +8,13 @@
     β∞::T 
 end
 
-function SimplePlastic(mp::Plastic)
-    if !isa(mp.elastic, LinearElastic{<:Any, :isotropic})
-        error("elastic part must be isotropic")
-    end
-    isa(mp.yield, VonMises) || error("yield criterion must be von Mises")
-    if length(mp.isotropic) != 1
-        if !isa(only(mp.isotropic), Voce)
-            error("Only a single isotropic hardening, which must be Voce, is allowed")
-        end
-    end
-    if length(mp.kinematic) != 1
-        if isa(only(mp.kinematic), ArmstrongFrederick)
-            error("Only a single kinematic hardening, which must be ArmstrongFrederick, is allowed")
-        end
-    end
-    isa(mp.overstress, RateIndependent) || error("Only rate-independent material allowed")
+function SimplePlastic(mp::Plastic{Ela, Yld, Iso, Kin, Rat}) where {
+        Ela <: LinearElastic{<:Any, :isotropic},
+        Yld <: VonMises,
+        Iso <: Tuple{<:Voce},
+        Kin <: Tuple{<:ArmstrongFrederick},
+        Rat <: RateIndependent
+        }
     
     E, ν = mp.elastic.p 
     return SimplePlastic(;

--- a/src/specialized_models/SimplePlastic.jl
+++ b/src/specialized_models/SimplePlastic.jl
@@ -100,7 +100,9 @@ function residual(Δλ, m::SimplePlastic, ϵ::SymmetricTensor, old::SimplePlasti
     return Φ
 end
 
-
+#=
+# Extra stability, but doesn't seem to be hit in normal cases.
+# Therefore, excluded as it is not tested.
 function bisect_solve(rf, x0::Number; maxiter = 200, tol = 1e-6)
     x_left = zero(x0)
     x_right = x0
@@ -137,3 +139,4 @@ function bisect_solve(rf, x0::Number; maxiter = 200, tol = 1e-6)
     end
     error("Did not find sufficiently small residual")
 end
+=#

--- a/test/test_plastic.jl
+++ b/test/test_plastic.jl
@@ -123,7 +123,7 @@ end
     @test ϵ ≈ ϵ_s
 
     # Test stability
-    γv = [0.0, 0.5, -0.5, 0.0, -1.0, 1.0];
+    γv = [0.0, 0.5, -0.5, 0.0, -1.0, 1.0]
     @test_throws NoLocalConvergence run_shear(m0, γv)
     run_shear(m0_simple, γv)
 end

--- a/test/test_plastic.jl
+++ b/test/test_plastic.jl
@@ -1,54 +1,3 @@
-@testset "SimplePlastic" begin
-    # Run an example, compare with SimplePlastic
-    E = 210.e3;     ν = 0.3
-    Y0 = 150.0
-    Hkin = 1 * 10e3;    β∞ = 25.0
-    Hiso = 1 * 13e3;    κ∞ = 35.0
-    G = E/(2 * (1 + ν))
-    K = E / (3 * (1 - 2 * ν))
-    elastic = LinearElastic(;E, ν)
-    kinematic = ArmstrongFrederick(;Hkin, β∞)
-    isotropic = Voce(;Hiso, κ∞)
-    m0 = Plastic(;elastic, yield = Y0, kinematic, isotropic)
-    m0_simple = SimplePlastic(; G, K, Y0, Hiso, κ∞, Hkin, β∞)
-
-    Δϵ21 = 0.01
-    N = 100
-    s21, σ, dσdϵ, state, ϵ0 = run_shear(m0, Δϵ21, N)
-
-    ϵp_old = state.ϵp
-    κold = state.κ[1]
-    βold = state.β[1]
-    old = MechanicalMaterialModels.SimplePlasticState(ϵp_old, βold, κold)
-
-    ϵt = SymmetricTensor{2,3}((i,j) -> i==2 && j==1 ? ϵ0[i, j] + 1e-4 : 0.0)
-
-    extras = allocate_differentiation_output(m0)
-    σ1, dσdϵ1, state1 = material_response(m0, ϵt, state, 0.1, allocate_material_cache(m0), extras)
-
-    σ_s, dσdϵ_s, state_s = material_response(m0_simple, ϵt, old, 0.1)
-
-    Δλ = extras.X.Δλ
-    # κ = MechanicalMaterialModels.calculate_κ(Δλ, m0_simple, old)
-    σdev, β, κ = MechanicalMaterialModels.calculate_evolution(Δλ, m0_simple, ϵt, old)
-
-    @test state1.κ[1] ≈ state_s.κ ≈ κ
-    @test state1.β[1] ≈ state_s.β ≈ β
-    @test state1.ϵp ≈ state_s.ϵp
-    @test dev(σ1) ≈ dev(σ_s) ≈ σdev
-    @test σ1 ≈ σ_s
-    
-    Δϵ21 = 0.01
-    N = 100
-    s21, σ, dσdϵ, state, ϵ = run_shear(m0, Δϵ21, N)
-    s21_s, σ_s, dσdϵ_s, state_s, ϵ_s = run_shear(m0_simple, Δϵ21, N)
-    # Using tol=1e-10 in newtonsolve inside material_response makes them pass standard ≈ test...
-    @test isapprox(s21, s21_s; atol = abs(s21[end]) * 1e-6)
-    @test σ ≈ σ_s
-    @test dσdϵ ≈ dσdϵ_s
-    @test ϵ ≈ ϵ_s 
-end
-
 @testset "Plastic" begin
     (E, ν) = pel = [210.e3, 0.3]
     e = LinearElastic(E=E, ν=ν)
@@ -117,4 +66,64 @@ end
     @test contains(show_str, "Voce")
     @test contains(show_str, "ArmstrongFrederick")
     @test contains(show_str, "Norton overstress")
+end
+
+@testset "SimplePlastic" begin
+    # Run an example, compare with Plastic
+    E = 210.e3;     ν = 0.3
+    Y0 = 150.0
+    Hkin = 1 * 10e3;    β∞ = 25.0
+    Hiso = 1 * 13e3;    κ∞ = 35.0
+    G = E/(2 * (1 + ν))
+    K = E / (3 * (1 - 2 * ν))
+    elastic = LinearElastic(;E, ν)
+    kinematic = ArmstrongFrederick(;Hkin, β∞)
+    isotropic = Voce(;Hiso, κ∞)
+    m0 = Plastic(;elastic, yield = Y0, kinematic, isotropic)
+    m0_simple = SimplePlastic(; G, K, Y0, Hiso, κ∞, Hkin, β∞)
+    m0_simple_from_plastic = SimplePlastic(m0)
+    for key in fieldnames(typeof(m0_simple))
+        @test getproperty(m0_simple, key) ≈ getproperty(m0_simple_from_plastic, key)
+    end
+
+    Δϵ21 = 0.01
+    N = 100
+    s21, σ, dσdϵ, state, ϵ0 = run_shear(m0, Δϵ21, N)
+
+    ϵp_old = state.ϵp
+    κold = state.κ[1]
+    βold = state.β[1]
+    old = MechanicalMaterialModels.SimplePlasticState(ϵp_old, βold, κold)
+
+    ϵt = SymmetricTensor{2,3}((i,j) -> i==2 && j==1 ? ϵ0[i, j] + 1e-4 : 0.0)
+
+    extras = allocate_differentiation_output(m0)
+    σ1, dσdϵ1, state1 = material_response(m0, ϵt, state, 0.1, allocate_material_cache(m0), extras)
+
+    σ_s, dσdϵ_s, state_s = material_response(m0_simple, ϵt, old, 0.1)
+
+    Δλ = extras.X.Δλ
+    # κ = MechanicalMaterialModels.calculate_κ(Δλ, m0_simple, old)
+    σdev, β, κ = MechanicalMaterialModels.calculate_evolution(Δλ, m0_simple, ϵt, old)
+
+    @test state1.κ[1] ≈ state_s.κ ≈ κ
+    @test state1.β[1] ≈ state_s.β ≈ β
+    @test state1.ϵp ≈ state_s.ϵp
+    @test dev(σ1) ≈ dev(σ_s) ≈ σdev
+    @test σ1 ≈ σ_s
+
+    Δϵ21 = 0.01
+    N = 100
+    s21, σ, dσdϵ, state, ϵ = run_shear(m0, Δϵ21, N)
+    s21_s, σ_s, dσdϵ_s, state_s, ϵ_s = run_shear(m0_simple, Δϵ21, N)
+    # Using tol=1e-10 in newtonsolve inside material_response makes them pass standard ≈ test...
+    @test isapprox(s21, s21_s; atol = abs(s21[end]) * 1e-6)
+    @test σ ≈ σ_s
+    @test dσdϵ ≈ dσdϵ_s
+    @test ϵ ≈ ϵ_s
+
+    # Test stability
+    γv = [0.0, 0.5, -0.5, 0.0, -1.0, 1.0];
+    @test_throws NoLocalConvergence run_shear(m0, γv)
+    run_shear(m0_simple, γv)
 end

--- a/test/test_plastic.jl
+++ b/test/test_plastic.jl
@@ -1,3 +1,54 @@
+@testset "SimplePlastic" begin
+    # Run an example, compare with SimplePlastic
+    E = 210.e3;     ν = 0.3
+    Y0 = 150.0
+    Hkin = 1 * 10e3;    β∞ = 25.0
+    Hiso = 1 * 13e3;    κ∞ = 35.0
+    G = E/(2 * (1 + ν))
+    K = E / (3 * (1 - 2 * ν))
+    elastic = LinearElastic(;E, ν)
+    kinematic = ArmstrongFrederick(;Hkin, β∞)
+    isotropic = Voce(;Hiso, κ∞)
+    m0 = Plastic(;elastic, yield = Y0, kinematic, isotropic)
+    m0_simple = SimplePlastic(; G, K, Y0, Hiso, κ∞, Hkin, β∞)
+
+    Δϵ21 = 0.01
+    N = 100
+    s21, σ, dσdϵ, state, ϵ0 = run_shear(m0, Δϵ21, N)
+
+    ϵp_old = state.ϵp
+    κold = state.κ[1]
+    βold = state.β[1]
+    old = MechanicalMaterialModels.SimplePlasticState(ϵp_old, βold, κold)
+
+    ϵt = SymmetricTensor{2,3}((i,j) -> i==2 && j==1 ? ϵ0[i, j] + 1e-4 : 0.0)
+
+    extras = allocate_differentiation_output(m0)
+    σ1, dσdϵ1, state1 = material_response(m0, ϵt, state, 0.1, allocate_material_cache(m0), extras)
+
+    σ_s, dσdϵ_s, state_s = material_response(m0_simple, ϵt, old, 0.1)
+
+    Δλ = extras.X.Δλ
+    # κ = MechanicalMaterialModels.calculate_κ(Δλ, m0_simple, old)
+    σdev, β, κ = MechanicalMaterialModels.calculate_evolution(Δλ, m0_simple, ϵt, old)
+
+    @test state1.κ[1] ≈ state_s.κ ≈ κ
+    @test state1.β[1] ≈ state_s.β ≈ β
+    @test state1.ϵp ≈ state_s.ϵp
+    @test dev(σ1) ≈ dev(σ_s) ≈ σdev
+    @test σ1 ≈ σ_s
+    
+    Δϵ21 = 0.01
+    N = 100
+    s21, σ, dσdϵ, state, ϵ = run_shear(m0, Δϵ21, N)
+    s21_s, σ_s, dσdϵ_s, state_s, ϵ_s = run_shear(m0_simple, Δϵ21, N)
+    # Using tol=1e-10 in newtonsolve inside material_response makes them pass standard ≈ test...
+    @test isapprox(s21, s21_s; atol = abs(s21[end]) * 1e-6)
+    @test σ ≈ σ_s
+    @test dσdϵ ≈ dσdϵ_s
+    @test ϵ ≈ ϵ_s 
+end
+
 @testset "Plastic" begin
     (E, ν) = pel = [210.e3, 0.3]
     e = LinearElastic(E=E, ν=ν)

--- a/test/utilities4testing.jl
+++ b/test/utilities4testing.jl
@@ -1,12 +1,16 @@
-function run_shear(m, γmax, numsteps, Δt = nothing; TT=SymmetricTensor)
+function run_shear(m, γmax::Number, numsteps::Int, Δt = nothing; TT=SymmetricTensor)
+    γv = range(0, γmax, numsteps + 1)
+    return run_shear(m, γv, Δt; TT)
+end
+
+function run_shear(m, γv::AbstractVector, Δt = nothing; TT = SymmetricTensor)
     state = initial_material_state(m)
-    Δϵ = TT{2,3}((i,j)-> i==2 && j==1 ? γmax/numsteps : zero(γmax))
-    s21 = zeros(numsteps+1)
+    s21 = zeros(length(γv))
     local σ, dσdϵ, ϵ
-    for i = 1:numsteps
-        ϵ = i*Δϵ
+    for (k, ϵ21) in enumerate(γv[2:end])
+        ϵ = TT{2,3}((i,j)-> i==2 && j==1 ? ϵ21 : zero(ϵ21))
         σ, dσdϵ, state = material_response(m, ϵ, state, Δt)
-        s21[i+1] = σ[2,1]
+        s21[k+1] = σ[2,1]
     end
     return s21, σ, dσdϵ, state, ϵ
 end


### PR DESCRIPTION
A specialized version of the rate-independent `Plastic` model with linear isotropic elasticity, `Voce` isotropic hardening and `ArmstrongFrederick` kinematic hardening. By reducing the residual equation to a scalar problem, this will converge in more challenging cases, and can be used both for debugging and accelerating (FE) simulations. 