### PR TITLE
Fix sign in isotropic hardening equation

### DIFF
--- a/src/plasticity_components/IsotropicHardening.jl
+++ b/src/plasticity_components/IsotropicHardening.jl
@@ -10,7 +10,7 @@ get_initial_value(::AbstractIsotropicHardening{T}) where {T} = zero(T)
 Exponentially saturating isotropic hardening
 
 ```math
-\\kappa_i = g_{\\mathrm{iso},i}(\\lambda) = \\kappa_\\infty \\left[1 - \\mathrm{exp}\\left(\\frac{H_\\mathrm{iso}}{\\kappa_\\infty} \\lambda \\right)\\right]
+\\kappa_i = g_{\\mathrm{iso},i}(\\lambda) = \\kappa_\\infty \\left[1 - \\mathrm{exp}\\left(-\\frac{H_\\mathrm{iso}}{\\kappa_\\infty} \\lambda \\right)\\right]
 ```
 or alternatively as differential equations
 ```math


### PR DESCRIPTION
Fixed a typo in the documentation. The implementation is unchanged.